### PR TITLE
Add 'Cache-Control' to headers

### DIFF
--- a/badge.js
+++ b/badge.js
@@ -1,4 +1,4 @@
-'use script';
+"use strict";
 
 const badge = require('gh-badges');
 const BADGE_FONT = './Verdana.ttf';
@@ -13,17 +13,17 @@ let Badge = function Badge() {
 Badge.prototype.setText = function(textA, textB) {
   this.text = [textA, textB];
   return this;
-}
+};
 
 Badge.prototype.setColorscheme = function(colorscheme) {
   this.colorscheme = colorscheme;
   return this;
-}
+};
 
 Badge.prototype.setTemplate = function(template) {
   this.template = template;
   return this;
-}
+};
 
 Badge.prototype.getOpts = function() {
   return {
@@ -32,7 +32,7 @@ Badge.prototype.getOpts = function() {
     logo: PT_LOGO,
     template: this.template
   };
-}
+};
 
 Badge.prototype.build = function(cb) {
   let scope = this;

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ else if(!process.env.PIVOTAL_API_KEY) {
 
 
 function getStoryBadge(req, res) {
+  res.append('Cache-Control', 'no-cache, no-store, must-revalidate');
+  //Past expiration forces re-fetching images each time.
+  res.append('Expires', 'Wed, 21 Oct 2015 07:28:00 GMT');
   const UUID = req.params.uuid || null;
   db.getKey(req.params.uuid, function(key) {
     const storyId = req.params.storyId;


### PR DESCRIPTION
 - no-cache and expiration is used to prevent GitHub from caching the
 images. That defeats the purpose of this!
 - lol 'use script'. Had to add semi-colons after changing to 'use
 strict'. I could not get node to compile without doing this.

Author: Jack Coy <Jackman3000@gmail.com>